### PR TITLE
Menu update for menus with more entries than can be displayed onscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+.vs/LaiNESwitch/v15/.suo
+.vs/LaiNESwitch/v15/Browse.VC.db
+.vs/LaiNESwitch/v15/Browse.VC.opendb
+.vs/ProjectSettings.json
+.vs/slnx.sqlite
+.vs/VSWorkspaceState.json
+.vscode/c_cpp_properties.json

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -63,7 +63,7 @@ void Menu::add(Entry* entry)
 {
     if (entries.empty())
         entry->select();
-    entry->setY(entries.size() * FONT_SZ);
+    
     entries.push_back(entry);
 }
 
@@ -79,10 +79,17 @@ void Menu::update(int joy)
 {
     int oldCursor = cursor;
 
-    if (((joy == JOY_DOWN) or (joy == JOY_LSTICK_DOWN)) and cursor < entries.size() - 1)
+    if (((joy == JOY_DOWN) or (joy == JOY_LSTICK_DOWN)) and cursor < entries.size())
         cursor++;
-    else if (((joy == JOY_UP) or (joy == JOY_LSTICK_UP)) and cursor > 0)
+    else if (((joy == JOY_UP) or (joy == JOY_LSTICK_UP)) and cursor >= 0)
         cursor--;
+
+	if (cursor < 0)
+		cursor = entries.size();
+	else if (cursor >= entries.size())
+		cursor = 0;
+
+	displayOffset = cursor / entryDisplayLimit;
 
     entries[oldCursor]->unselect();
     entries[cursor]->select();
@@ -93,8 +100,14 @@ void Menu::update(int joy)
 
 void Menu::render()
 {
-    for (auto entry : entries)
-        entry->render();
+   /* for (auto entry : entries)
+        entry->render();*/
+	for (int it = 0; it < entryDisplayLimit; it++) {
+		int relPos = it;
+		relPos += displayOffset * entryDisplayLimit;
+		entries[relPos]->setY(it * FONT_SZ);
+		entries[relPos]->render();
+	}
 }
 
 void FileMenu::change_dir(string dir)

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -85,7 +85,7 @@ void Menu::update(int joy)
         cursor--;
 
 	if (cursor < 0)
-		cursor = entries.size();
+		cursor = entries.size()-1;
 	else if (cursor >= entries.size())
 		cursor = 0;
 

--- a/source/menu.hpp
+++ b/source/menu.hpp
@@ -52,6 +52,8 @@ class ControlEntry : public Entry
 class Menu
 {
     std::vector<Entry*> entries;
+	int entryDisplayLimit = (HEIGHT / FONT_SZ);
+	int displayOffset = 0;
     int cursor = 0;
 
   public:


### PR DESCRIPTION
Handles menus with more entries than can be displayed on-screen, and wraps cursor for all menus. When the cursor moves to an off-screen entry (as defined by the entryDisplayLimit defined by the screen height and font size), the displayOffset changes.