### PR TITLE
Several fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.*/
+build/
+*~
+*.bak
+*.nro
+*.nso
+*.nacp
+*.pfs0
+*.elf

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ INCLUDES	:=	source \
 				$(EXT_LIBS)
 
 EXEFS_SRC	:=	exefs_src
-ROMFS		:=	game
+#ROMFS		:=	game
 
 APP_TITLE	:= LaiNes
 APP_AUTHOR	:= Kevoot

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -2,7 +2,7 @@
 #include <sys/stat.h>
 #include <SDL2/SDL.h>
 
-#define CONFIG_FALLBACK ".settings"
+#define CONFIG_FALLBACK "/LaiNes.settings"
 
 #define JOY_A     0
 #define JOY_B     1

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -153,7 +153,7 @@ void init()
                                     SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
                                     WIDTH, HEIGHT);
 
-    font = TTF_OpenFont("sdmc:/res/font.ttf", FONT_SZ);
+    font = TTF_OpenFont("res/font.ttf", FONT_SZ);
     if(!font) {
         printf("Failed to open res/font.ttf!");
         exit(1);
@@ -169,7 +169,7 @@ void init()
         exit(1);
     }
 
-    SDL_Surface *backSurface = IMG_Load("sdmc:/res/init.png");
+    SDL_Surface *backSurface = IMG_Load("res/init.png");
 
     background = SDL_CreateTextureFromSurface(renderer, backSurface);
 


### PR DESCRIPTION
* Fixes build errors
* Replaces hardcoded absolute paths by relative paths
* Puts settings in NRO folder instead of in the parent folder
* Adds .gitignore

Also, please make sure to upgrade to latest stable devkitA64 and libnx (r12 and v1.3.2 respectively at the time of writing). Latest libnx contains a critical bugfix for cwd access, as well as fatal errors being no longer erroneously submitted as a Nintendo error report.